### PR TITLE
Create directory with container user permission.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM curlimages/curl:7.85.0 AS builder
 ARG FIRMWARE_VERSION=0.16.765
 
+RUN mkdir /tmp/obs
 WORKDIR /tmp/obs
 RUN curl --remote-name --location https://github.com/openbikesensor/OpenBikeSensorFirmware/releases/download/v${FIRMWARE_VERSION}/obs-v${FIRMWARE_VERSION}-initial-flash.zip && \
     curl --remote-name --location  https://github.com/openbikesensor/OpenBikeSensorFlash/releases/latest/download/flash.bin && \


### PR DESCRIPTION
This PR fixes an error which occures during the build of the Docker image.

Following error is displayed during the execution of `docker build ...`
```
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
Warning: Failed to open the file obs-v0.16.765-initial-flash.zip: Permission 
Warning: denied
  0 1307k    0  1369    0     0   1561      0  0:14:17 --:--:--  0:14:17  1561
curl: (23) Failure writing output to destination
```

The reson is, that in step `WORKDIR /tmp/obs` the directory is created by user `root`.
Later in step `RUN curl ...` the command is executed by user `curl_user`, who has no permission to write the output file into `/tmp/obs`.

**check directory permission**

Dockerfile
```
FROM curlimages/curl:7.85.0 AS builder
WORKDIR /tmp/obs
```

build with
```
docker build --tag openbikesensor/openbikesensorflasher:permissions .
```

display the directory permissions
```
$ docker run --rm --entrypoint /bin/sh openbikesensor/openbikesensorflasher:permissions -c "/bin/ls -ld /tmp/obs"
drwxr-xr-x    2 root     root          4096 Sep 28 21:24 /tmp/obs
```

**check container user**
```
$ docker run --rm --entrypoint /bin/sh openbikesensor/openbikesensorflasher:permissions -c "id"
uid=100(curl_user) gid=101(curl_group) groups=101(curl_group)
```