### PR TITLE
Make the note about unsupported browser more visible.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,8 @@ RUN curl --remote-name --location https://github.com/esphome/esp-web-tools/archi
     unzip *.zip && \
     rm *.zip && \
     mv */* . && \
+# make unsupported browser hint more visible
+    sed -i "/'unsupported'/ s|\(<slot.*unsupported.*slot>\)|<div style='font-size:xx-large;color:red;font-weight:bold;'>\1</div>|" src/install-button.ts && \
 # increase speed
     sed -i 's|esploader.flash_id();|esploader.flash_id();\n    await esploader.change_baud();|g' src/flash.ts && \
     sed -i 's|115200|921600|g' src/flash.ts && \


### PR DESCRIPTION
The hint of using an unsupported browser is displayed in the middle of the page, but it is not very obvious.

This PR makes it more noticeable.

**before**

![image](https://user-images.githubusercontent.com/653288/194950009-8b8b6cc4-ab97-46ba-88be-2549622247ee.png)

**after**

![image](https://user-images.githubusercontent.com/653288/194950089-387cc40a-5395-469a-a9d8-082be5448b82.png)
